### PR TITLE
unstick-navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 academy-powertoys.user.js
+*.html

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ FILES=(
   src/features/global/dismiss-adblock.js
   src/features/global/theme-mode.js
   src/features/global/hover-prefetch.js
+  src/features/global/unstick-navbar.js
 
   # Dashboard features
   src/features/dashboard/default-enrolled-path-tab.js

--- a/src/features/global/unstick-navbar.js
+++ b/src/features/global/unstick-navbar.js
@@ -1,0 +1,20 @@
+  registerFeature({
+    id: 'unstick-navbar',
+    label: 'Non-Sticky Nav Bar',
+    description: 'Make the top navigation bar scroll with the page instead of staying fixed',
+    scope: 'global',
+    default: true,
+    cleanup() { document.getElementById('apt-unstick-navbar')?.remove(); },
+    run() {
+      const styleId = 'apt-unstick-navbar';
+      if (document.getElementById(styleId)) return;
+      const style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = `
+        header.sticky, header nav.sticky {
+          position: relative !important;
+        }
+      `;
+      document.head.appendChild(style);
+    },
+  });


### PR DESCRIPTION
Makes it so the top navigation bar does not take up extra space on the screen by making it static