### PR TITLE
fix module expand/collapse all bug

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,7 @@ FILES=(
   src/features/module/green-inline-code.js
   src/features/module/toc-real-links.js
   src/features/module/expand-menu.js
+  src/features/module/fix-collapse-all.js
   src/features/module/expand-current-module-info.js
   src/features/module/expand-questions.js
   src/features/module/hide-solutions-promo.js

--- a/src/features/module/expand-current-module-info.js
+++ b/src/features/module/expand-current-module-info.js
@@ -4,13 +4,18 @@
     description: 'On module overview pages, auto-expand all syllabus sections',
     scope: 'module',
     default: true,
+    cleanup() {
+      if (window._aptExpandAllModuleInfoObs) {
+        window._aptExpandAllModuleInfoObs.disconnect();
+        delete window._aptExpandAllModuleInfoObs;
+      }
+      delete window._aptExpandedModuleInfoPath;
+    },
     run() {
       if (!/^\/app\/module\/\d+\/?$/.test(location.pathname)) return;
-
-      let done = false;
-
-      function expandAll() {
-        if (done) return true;
+      const infoPath = location.pathname;
+      if (window._aptExpandedModuleInfoPath === infoPath) return;
+      function expandAllOnce() {
 
         const container = document.querySelector('.module-sections');
         if (!container) return false;
@@ -18,23 +23,44 @@
         const collapses = [...container.querySelectorAll('.collapse')];
         if (collapses.length === 0) return false;
 
-        done = true;
-
         collapses.forEach(collapse => {
           if (collapse.classList.contains('collapse-open')) return;
           const cb = collapse.querySelector('input[name="base-accordion-checkbox"], input[type="checkbox"]');
           if (cb && !cb.checked) cb.click();
         });
 
+        window._aptExpandedModuleInfoPath = infoPath;
+        if (typeof window._aptCollapseAllSync === 'function') {
+          window._aptCollapseAllSync();
+        }
+
         return true;
       }
 
-      if (!expandAll()) {
-        const obs = new MutationObserver((_, o) => {
-          if (expandAll()) o.disconnect();
-        });
-        obs.observe(document.body, { childList: true, subtree: true });
-        setTimeout(() => obs.disconnect(), 10000);
+      if (expandAllOnce()) {
+        if (window._aptExpandAllModuleInfoObs) {
+          window._aptExpandAllModuleInfoObs.disconnect();
+          delete window._aptExpandAllModuleInfoObs;
+        }
+        return;
       }
+
+      if (window._aptExpandAllModuleInfoObs) return;
+      const obs = new MutationObserver(() => {
+        if (window._aptExpandedModuleInfoPath === infoPath || expandAllOnce()) {
+          obs.disconnect();
+          if (window._aptExpandAllModuleInfoObs === obs) {
+            delete window._aptExpandAllModuleInfoObs;
+          }
+        }
+      });
+      obs.observe(document.body, { childList: true, subtree: true });
+      window._aptExpandAllModuleInfoObs = obs;
+      setTimeout(() => {
+        if (window._aptExpandAllModuleInfoObs === obs) {
+          obs.disconnect();
+          delete window._aptExpandAllModuleInfoObs;
+        }
+      }, 10000);
     },
   });

--- a/src/features/module/fix-collapse-all.js
+++ b/src/features/module/fix-collapse-all.js
@@ -1,0 +1,105 @@
+  registerFeature({
+    id: 'fix-collapse-all',
+    label: 'Fix Collapse/Expand All Sections',
+    description: 'Fix the broken "Collapse all sections" / "Expand all sections" toggle on module info pages',
+    scope: 'module',
+    default: true,
+    run() {
+      if (!/^\/app\/module\/\d+\/?$/.test(location.pathname)) return;
+
+      function getCheckbox(collapse) {
+        return collapse.querySelector('input[name="base-accordion-checkbox"], input[type="checkbox"]');
+      }
+
+      function isOpen(collapse) {
+        const cb = getCheckbox(collapse);
+        return collapse.classList.contains('collapse-open') || (cb && cb.checked);
+      }
+
+      // Use document-level capture listener so it fires before anything else
+      // and survives Vue re-renders
+      document.addEventListener('click', function(e) {
+        const link = e.target.closest('.module-sections .link-secondary-htb');
+        if (!link) return;
+        if (!/collapse|expand/i.test(link.textContent)) return;
+
+        e.stopImmediatePropagation();
+        e.stopPropagation();
+        e.preventDefault();
+
+        const container = document.querySelector('.module-sections');
+        if (!container) return;
+
+        const collapses = [...container.querySelectorAll('.collapse')];
+        if (collapses.length === 0) return;
+
+        const wantsCollapse = /collapse/i.test(link.textContent);
+
+        collapses.forEach(collapse => {
+          const cb = getCheckbox(collapse);
+          if (!cb) return;
+          const open = isOpen(collapse);
+          if (wantsCollapse && open) cb.click();
+          if (!wantsCollapse && !open) cb.click();
+        });
+
+        link.textContent = wantsCollapse ? 'Expand all sections' : 'Collapse all sections';
+      }, true);
+
+      // Sync button text on init + expose helpers
+      let inited = false;
+
+      function tryInit() {
+        if (inited) return true;
+        const container = document.querySelector('.module-sections');
+        if (!container) return false;
+        const link = container.querySelector('.link-secondary-htb');
+        if (!link) return false;
+
+        inited = true;
+
+        // Sync button text to actual state
+        const collapses = [...container.querySelectorAll('.collapse')];
+        const anyOpen = collapses.some(c => isOpen(c));
+        link.textContent = anyOpen ? 'Collapse all sections' : 'Expand all sections';
+
+        // Expose helpers for other features
+        window._aptToggleAllSections = function(wantsCollapse) {
+          const cont = document.querySelector('.module-sections');
+          if (!cont) return;
+          const lnk = cont.querySelector('.link-secondary-htb');
+          const allCollapses = [...cont.querySelectorAll('.collapse')];
+          allCollapses.forEach(collapse => {
+            const cb = getCheckbox(collapse);
+            if (!cb) return;
+            const open = isOpen(collapse);
+            if (wantsCollapse && open) cb.click();
+            if (!wantsCollapse && !open) cb.click();
+          });
+          if (lnk) {
+            lnk.textContent = wantsCollapse ? 'Expand all sections' : 'Collapse all sections';
+          }
+        };
+
+        window._aptCollapseAllSync = function() {
+          const cont = document.querySelector('.module-sections');
+          if (!cont) return;
+          const lnk = cont.querySelector('.link-secondary-htb');
+          if (!lnk) return;
+          const allCollapses = [...cont.querySelectorAll('.collapse')];
+          const allOpen = allCollapses.every(c => isOpen(c));
+          lnk.textContent = allOpen ? 'Collapse all sections' : 'Expand all sections';
+        };
+
+        return true;
+      }
+
+      if (!tryInit()) {
+        const obs = new MutationObserver((_, o) => {
+          if (tryInit()) o.disconnect();
+        });
+        obs.observe(document.body, { childList: true, subtree: true });
+        setTimeout(() => obs.disconnect(), 10000);
+      }
+    },
+  });


### PR DESCRIPTION
The module info page expand all sections and collapse all sections button was not working, this fixes that.