### PR TITLE
feat: added another slider to adjust toc width

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,7 @@ FILES=(
 
   # Module features
   src/features/module/widen-content.js
+  src/features/module/toc-sidebar-width.js
   src/features/module/static-bottom-bar.js
   src/features/module/slim-bottom-bar.js
   src/features/module/green-inline-code.js

--- a/src/features/module/toc-sidebar-width.js
+++ b/src/features/module/toc-sidebar-width.js
@@ -1,0 +1,35 @@
+registerFeature({
+  id: 'toc-sidebar-width',
+  label: 'TOC Sidebar Width',
+  description: 'Adjust the inline TOC sidebar width (only applies when Widen Content is on)',
+  scope: 'module',
+  default: false,
+  hotReload: true,
+  settings: { width: 35 },
+  settingsUI: {
+    type: 'range',
+    key: 'width',
+    min: 30,
+    max: 50,
+    step: 1,
+    unit: 'vw',
+  },
+  cleanup() {
+    document.getElementById('apt-toc-sidebar-width')?.remove();
+  },
+  run(cfg) {
+    const styleId = 'apt-toc-sidebar-width';
+    document.getElementById(styleId)?.remove();
+    const vw = cfg.width || 30;
+    const minPx = Math.round(vw * 8);
+    const maxPx = Math.round(vw * 14);
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = `
+      .module-lab-row.apt-toc-inline-layout {
+        grid-template-columns: minmax(0, 1fr) clamp(${minPx}px, ${vw}vw, ${maxPx}px) !important;
+      }
+    `;
+    document.head.appendChild(style);
+  },
+});

--- a/src/ui/settings-panel.js
+++ b/src/ui/settings-panel.js
@@ -184,6 +184,7 @@
           const ui = feat.settingsUI;
           const cfg = getFeatureSettings(feat.id);
           const current = Number(cfg[ui.key] ?? feat.settings[ui.key]);
+          const unit = ui.unit || '%';
           row.innerHTML = `
             <div class="apt-feature-info">
               <div class="apt-feature-label">${label}</div>
@@ -193,6 +194,7 @@
                 <input type="range" class="apt-range"
                   data-feature-range-id="${feat.id}"
                   data-range-key="${ui.key}"
+                  data-range-key="${unit}"
                   min="${ui.min}" max="${ui.max}" step="${ui.step}"
                   value="${current}"
                   ${!enabled ? 'disabled' : ''}>


### PR DESCRIPTION
A slider to adjust the width of TOC
Ranges from 30-50 (`30 being what it was before`)

<img width="1138" height="997" alt="image" src="https://github.com/user-attachments/assets/d03828f1-efbd-4fea-a8e1-cac44c109e1b" />
